### PR TITLE
Optimize code in phase1.hpp

### DIFF
--- a/src/phase1.hpp
+++ b/src/phase1.hpp
@@ -558,13 +558,11 @@ void* F1thread(int const index, uint8_t const k, const uint8_t* id, std::mutex* 
         // to increase CPU efficency.
         f1.CalculateBuckets(x, loopcount, f1_entries.get());
         for (uint32_t i = 0; i < loopcount; i++) {
-            uint8_t to_write[16];
             uint128_t entry;
 
             entry = (uint128_t)f1_entries[i] << (128 - kExtraBits - k);
             entry |= (uint128_t)x << (128 - kExtraBits - 2 * k);
-            Util::IntTo16Bytes(to_write, entry);
-            memcpy(&(right_writer_buf[i * entry_size_bytes]), to_write, 16);
+            Util::IntTo16Bytes(&right_writer_buf[i * entry_size_bytes], entry);
             right_writer_count++;
             x++;
         }


### PR DESCRIPTION
	memcpy(&(right_writer_buf[i * entry_size_bytes]), to_write, 16);
This memcpy function will be called 4194304000 times
we can use:
	Util::IntTo16Bytes(&right_writer_buf[i * entry_size_bytes], entry);
instead of:
	Util::IntTo16Bytes(to_write, entry);
	memcpy(&(right_writer_buf[i * entry_size_bytes]), to_write, 16);

Delete memcpy function 